### PR TITLE
chore(build): publish to maven central portal

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,15 @@ jobs:
     name: Deploy to package index
     runs-on: ubuntu-24.04
     env:
-      MAVEN_SNAPSHOTS_URL: ${{ secrets.OSSRH_SNAPSHOT_URL }}
-      MAVEN_RELEASES_URL: ${{ secrets.OSSRH_RELEASE_URL }}
-      MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+      JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_PORTAL_USERNAME }}
+      JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PORTAL_PASSWORD }}
+      JRELEASER_NEXUS2_USERNAME: ${{ secrets.MAVEN_CENTRAL_PORTAL_USERNAME }}
+      JRELEASER_NEXUS2_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PORTAL_PASSWORD }}
+      JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+      JRELEASER_MAVENCENTRAL_STAGE: ${{ vars.MAVEN_CENTRAL_STAGE }} # Default is "FULL" https://jreleaser.org/guide/latest/reference/deploy/maven/maven-central.html#_staged_deployments
 
     steps:
       - name: Checkout repository
@@ -24,14 +29,14 @@ jobs:
           distribution: zulu
           java-version: "8"
 
-      - name: Decode signing key ring
-        run: |
-          mkdir -p ~/.gradle
-          echo "${{secrets.SIGNING_SECRET_KEY_RING_FILE}}" > ~/.gradle/secring.gpg.b64
-          base64 -d ~/.gradle/secring.gpg.b64 > ~/.gradle/secring.gpg
+      - name: Verify JReleaser configuration
+        run: ./gradlew jreleaserConfig
 
       - name: Clean build directory
         run: ./gradlew clean
 
-      - name: Publish
-        run: ./gradlew publish -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=${{secrets.SIGNING_KEY_PASSWORD}} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg) --info --console plain
+      - name: Publish (Stage to local directory)
+        run: ./gradlew publish --info --console plain
+
+      - name: Deploy and release
+        run: ./gradlew jreleaserFullRelease --stacktrace --info --console plain

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To be able to install snapshot releases of the sdk an additional repository must
     <repository>
         <id>sonatype</id>
         <name>sonatype-snapshot</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>
@@ -64,7 +64,7 @@ To be able to install snapshot releases of the sdk an additional repository must
 repositories {
     mavenCentral()
     maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         mavenContent {
             snapshotsOnly()
         }
@@ -270,7 +270,7 @@ The logger `com.factset.sdk.utils.authentication.ConfidentialClient` logs out th
 
 # Copyright
 
-Copyright 2024 FactSet Research Systems Inc
+Copyright 2025 FactSet Research Systems Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,17 @@
+import java.time.LocalDate
+
+plugins {
+    id 'java-library'
+    id 'signing'
+    id 'jacoco'
+    id 'maven-publish'
+    id 'org.jreleaser' version '1.17.0'
+}
+
 repositories {
     mavenLocal()
     mavenCentral()
 }
-
-apply plugin: 'java-library'
-apply plugin: 'signing'
-apply plugin: 'jacoco'
-apply plugin: 'maven-publish'
 
 group 'com.factset.sdk'
 version '1.1.4-SNAPSHOT'
@@ -68,6 +73,8 @@ artifacts {
     archives sourcesJar
 }
 
+def artifactStagingDirectory = layout.buildDirectory.dir("build/staging-deploy")
+
 publishing {
     publications {
         register("mavenJava", MavenPublication) {
@@ -104,20 +111,61 @@ publishing {
 
     repositories {
         maven {
-            url = version.endsWith('SNAPSHOT') ? System.getenv('MAVEN_SNAPSHOTS_URL') : System.getenv('MAVEN_RELEASES_URL')
-
-            credentials {
-                username = System.getenv('MAVEN_USERNAME')
-                password = System.getenv('MAVEN_PASSWORD')
-            }
-
-            authentication {
-                digest(BasicAuthentication)
-            }
+            url = uri(artifactStagingDirectory)
         }
     }
 }
 
-signing {
-    sign publishing.publications.mavenJava
+jreleaser {
+    gitRootSearch = true
+
+    project {
+        description = 'FactSet SDK Utilities for Java'
+        authors = ['FactSet']
+        license = "APACHE-2.0"
+        inceptionYear = "2021"
+        vendor = "FactSet"
+        copyright = "Copyright (c) ${LocalDate.now().year} FactSet"
+        return // for the type checker
+    }
+
+    signing {
+        active = 'ALWAYS'
+        armored = true
+        return
+    }
+
+    release {
+        github {
+            skipTag = true
+            skipRelease = true
+            return
+        }
+    }
+
+    deploy {
+        maven {
+            mavenCentral {
+                'release-deploy' {
+                    active = 'RELEASE'
+                    url = "https://central.sonatype.com/api/v1/publisher"
+                    stagingRepository artifactStagingDirectory.get().asFile.path
+                }
+                return
+            }
+            nexus2 {
+                'snapshot-deploy' {
+                    active = 'SNAPSHOT'
+                    url = "https://central.sonatype.com/repository/maven-snapshots/"
+                    snapshotUrl = "https://central.sonatype.com/repository/maven-snapshots/"
+                    applyMavenCentralRules = true
+                    snapshotSupported = true
+                    closeRepository = true
+                    releaseRepository = true
+                    stagingRepository artifactStagingDirectory.get().asFile.path
+                }
+                return
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Description

This PR moves our publishing setup from OSSRH to [Maven Central](https://central.sonatype.org/pages/ossrh-eol/#process-to-migrate).

### Links

* same change as in https://github.com/factset/enterprise-sdk-eventdriven-factsettrading-java/pull/87

### Testing


### Checklist

Ensure the following things have been met before requesting a review:

* [ ] Follows all project developer guide and coding standards.
* [ ] Tests have been written for the change, when applicable.
* [ ] Confidential information (credentials, auth tokens, etc...) is not included.
