### PR TITLE
feat(java): forced access token refresh and expiry buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ public class Console {
 }
 ```
 
-> Token refresh note: `getAccessToken()` (or `getAccessToken(false)`) returns the cached token while valid. Call `getAccessToken(true)` to bypass the cache and force retrieval of a new token.
+> Token refresh note: `getAccessToken()` (or `getAccessToken(false)`) returns the cached token while valid. Call `getAccessToken(true)` to bypass the cache and force retrieval of a new token. (See [Access Token Proactive Expiry Offset](#access-token-proactive-expiry-offset) for details on token expiry handling.)
 
 ### Configure a Proxy
 
@@ -187,16 +187,16 @@ The `ConfidentialClient` refreshes access tokens proactively before their actual
 Default behaviour:
 - A 30 second (30,000 ms) proactive offset is applied automatically.
 - Calls to `getAccessToken()` (or `getAccessToken(false)`) reuse the cached token while it is still considered valid under this adjusted expiry.
-- `getAccessToken(true)` always forces a fresh token (bypasses cache).
+- `getAccessToken(true)` forces a fresh token unless one was very recently refreshed (within 5 seconds) to avoid unnecessary duplicate requests from concurrent threads.
 
 You can override the proactive offset by configuring it in `RequestOptions`:
 
 #### Example
 ```java
-RequestOptions options10s = RequestOptions.builder()
-    .accessTokenExpiryOffsetMillis(90_000L) // 90 seconds
+RequestOptions options = RequestOptions.builder()
+    .accessTokenExpiryOffset(Duration.ofSeconds(90)) // 90 seconds
     .build();
-ConfidentialClient client10s = new ConfidentialClient("./path/to/config.json", options10s);
+ConfidentialClient client = new ConfidentialClient("./path/to/config.json", options);
 ```
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ public class Console {
 }
 ```
 
+> Token refresh note: `getAccessToken()` (or `getAccessToken(false)`) returns the cached token while valid. Call `getAccessToken(true)` to bypass the cache and force retrieval of a new token.
+
 ### Configure a Proxy
 
 The Confidential Client accepts an additional optional parameter called `RequestOptions`. This can be created to specify a proxy for the client to use. Below is an example of how to do this:

--- a/README.md
+++ b/README.md
@@ -180,6 +180,26 @@ RequestOptions reqOpt = RequestOptions.builder()
         .build();
 ```
 
+### Access Token Proactive Expiry Offset
+
+The `ConfidentialClient` refreshes access tokens proactively before their actual server-declared expiry to reduce the risk of a token expiring mid-request (e.g. due to latency or clock skew).
+
+Default behaviour:
+- A 30 second (30,000 ms) proactive offset is applied automatically.
+- Calls to `getAccessToken()` (or `getAccessToken(false)`) reuse the cached token while it is still considered valid under this adjusted expiry.
+- `getAccessToken(true)` always forces a fresh token (bypasses cache).
+
+You can override the proactive offset by supplying a custom value (milliseconds) via the constructor overload.
+
+#### Example
+```java
+ConfidentialClient client10s = new ConfidentialClient(
+    "./path/to/config.json",
+    RequestOptions.builder().build(),
+    10000L // 10 second proactive expiry offset
+);
+```
+
 ## Modules
 
 Information about the various utility modules contained in this library can be found below.

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The `ConfidentialClient` refreshes access tokens proactively before their actual
 Default behaviour:
 - A 30 second (30,000 ms) proactive offset is applied automatically.
 - Calls to `getAccessToken()` (or `getAccessToken(false)`) reuse the cached token while it is still considered valid under this adjusted expiry.
-- `getAccessToken(true)` forces a fresh token unless one was very recently refreshed (within 5 seconds) to avoid unnecessary duplicate requests from concurrent threads.
+- `getAccessToken(true)` forces a fresh token unless one was very recently refreshed (within 5 seconds) to avoid unnecessary duplicate requests.
 
 You can override the proactive offset by configuring it in `RequestOptions`:
 

--- a/README.md
+++ b/README.md
@@ -189,15 +189,14 @@ Default behaviour:
 - Calls to `getAccessToken()` (or `getAccessToken(false)`) reuse the cached token while it is still considered valid under this adjusted expiry.
 - `getAccessToken(true)` always forces a fresh token (bypasses cache).
 
-You can override the proactive offset by supplying a custom value (milliseconds) via the constructor overload.
+You can override the proactive offset by configuring it in `RequestOptions`:
 
 #### Example
 ```java
-ConfidentialClient client10s = new ConfidentialClient(
-    "./path/to/config.json",
-    RequestOptions.builder().build(),
-    10000L // 10 second proactive expiry offset
-);
+RequestOptions options10s = RequestOptions.builder()
+    .accessTokenExpiryOffsetMillis(90_000L) // 90 seconds
+    .build();
+ConfidentialClient client10s = new ConfidentialClient("./path/to/config.json", options10s);
 ```
 
 ## Modules

--- a/src/main/java/com/factset/sdk/utils/authentication/ConfidentialClient.java
+++ b/src/main/java/com/factset/sdk/utils/authentication/ConfidentialClient.java
@@ -69,7 +69,7 @@ public class ConfidentialClient implements OAuth2Client {
     public ConfidentialClient(final String configPath)
         throws AuthServerMetadataContentException, AuthServerMetadataException,
         ConfigurationException {
-        this(new Configuration(configPath), RequestOptions.builder().build());
+        this(new Configuration(configPath));
     }
 
     /**

--- a/src/main/java/com/factset/sdk/utils/authentication/ConfidentialClient.java
+++ b/src/main/java/com/factset/sdk/utils/authentication/ConfidentialClient.java
@@ -142,7 +142,7 @@ public class ConfidentialClient implements OAuth2Client {
         throws AuthServerMetadataContentException,
         AuthServerMetadataException,
         ConfigurationException {
-        this(new Configuration(configPath), RequestOptions.builder().build());
+        this(new Configuration(configPath));
         this.tokenRequestBuilder = tokReqBuilder.uri(this.providerMetadata.getTokenEndpointURI());
     }
 

--- a/src/main/java/com/factset/sdk/utils/authentication/ConfidentialClient.java
+++ b/src/main/java/com/factset/sdk/utils/authentication/ConfidentialClient.java
@@ -160,7 +160,7 @@ public class ConfidentialClient implements OAuth2Client {
     protected ConfidentialClient(final Configuration config, final TokenRequestBuilder tokReqBuilder)
         throws AuthServerMetadataContentException,
         AuthServerMetadataException {
-        this(config, RequestOptions.builder().build());
+        this(config);
         this.tokenRequestBuilder = tokReqBuilder.uri(this.providerMetadata.getTokenEndpointURI());
     }
 

--- a/src/main/java/com/factset/sdk/utils/authentication/Constants.java
+++ b/src/main/java/com/factset/sdk/utils/authentication/Constants.java
@@ -13,8 +13,10 @@ public final class Constants {
     // default values
     public static final String FACTSET_WELL_KNOWN_URI = "https://auth.factset.com/.well-known/openid-configuration";
 
-    // Buffer (in milliseconds) to refresh access token before actual expiry
-    public static final long ACCESS_TOKEN_EXPIRY_OFFSET_MILLIS = 30000; // 30 seconds
+    /**
+     * Default buffer (in milliseconds) to refresh access token before actual expiry.
+     */
+    public static final long DEFAULT_ACCESS_TOKEN_EXPIRY_OFFSET_MILLIS = 30000L;
 
     private Constants() {
         throw new IllegalStateException("Utility class");

--- a/src/main/java/com/factset/sdk/utils/authentication/Constants.java
+++ b/src/main/java/com/factset/sdk/utils/authentication/Constants.java
@@ -13,6 +13,9 @@ public final class Constants {
     // default values
     public static final String FACTSET_WELL_KNOWN_URI = "https://auth.factset.com/.well-known/openid-configuration";
 
+    // Buffer (in milliseconds) to refresh access token before actual expiry
+    public static final long ACCESS_TOKEN_EXPIRY_OFFSET_MILLIS = 30000; // 30 seconds
+
     private Constants() {
         throw new IllegalStateException("Utility class");
     }

--- a/src/main/java/com/factset/sdk/utils/authentication/Constants.java
+++ b/src/main/java/com/factset/sdk/utils/authentication/Constants.java
@@ -13,11 +13,6 @@ public final class Constants {
     // default values
     public static final String FACTSET_WELL_KNOWN_URI = "https://auth.factset.com/.well-known/openid-configuration";
 
-    /**
-     * Default buffer (in milliseconds) to refresh access token before actual expiry.
-     */
-    public static final long DEFAULT_ACCESS_TOKEN_EXPIRY_OFFSET_MILLIS = 30000L;
-
     private Constants() {
         throw new IllegalStateException("Utility class");
     }

--- a/src/main/java/com/factset/sdk/utils/authentication/RequestOptions.java
+++ b/src/main/java/com/factset/sdk/utils/authentication/RequestOptions.java
@@ -7,6 +7,9 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import java.net.Proxy;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Value
 @Builder
@@ -23,6 +26,30 @@ public class RequestOptions {
     @Builder.Default
     String userAgent = "fds-sdk/java/utils/1.1.5 (" + System.getProperty("os.name") + "; Java" + System.getProperty("java.version") + ")";
 
+    /**
+     * Maximum allowed proactive refresh offset (894 seconds).
+     */
+    public static final Duration MAX_PROACTIVE_OFFSET = Duration.ofSeconds(894);
+
+    private static final Logger LOG = LoggerFactory.getLogger(RequestOptions.class);
+
     @Builder.Default
-    long accessTokenExpiryOffsetMillis = 30_000L;
+    Duration accessTokenExpiryOffset = Duration.ofSeconds(30);
+
+
+    public static RequestOptionsBuilder builder() {
+        return new RequestOptionsBuilder() {
+
+            @Override
+            public RequestOptionsBuilder accessTokenExpiryOffset(Duration d) {
+                if (d == null) throw new IllegalArgumentException("accessTokenExpiryOffset cannot be null");
+                if (d.compareTo(MAX_PROACTIVE_OFFSET) > 0) {
+                    LOG.warn("Configured accessTokenExpiryOffset {} exceeds max {}; clamped to {}.", d, MAX_PROACTIVE_OFFSET, MAX_PROACTIVE_OFFSET);
+                    return super.accessTokenExpiryOffset(MAX_PROACTIVE_OFFSET);
+                }
+
+                return super.accessTokenExpiryOffset(d);
+            }
+        };
+    }
 }

--- a/src/main/java/com/factset/sdk/utils/authentication/RequestOptions.java
+++ b/src/main/java/com/factset/sdk/utils/authentication/RequestOptions.java
@@ -22,4 +22,7 @@ public class RequestOptions {
 
     @Builder.Default
     String userAgent = "fds-sdk/java/utils/1.1.5 (" + System.getProperty("os.name") + "; Java" + System.getProperty("java.version") + ")";
+
+    @Builder.Default
+    long accessTokenExpiryOffsetMillis = 30_000L;
 }

--- a/src/test/java/com/factset/sdk/utils/authentication/ConfidentialClientTest.java
+++ b/src/test/java/com/factset/sdk/utils/authentication/ConfidentialClientTest.java
@@ -330,29 +330,6 @@ class ConfidentialClientTest {
         verify(harness.httpRequestMock, times(1)).send();
     }
 
-    @Test
-    void getAccessTokenTwoDifferentThreadsSimultaneouslyOnlyFetchesOnce() throws Exception {
-        TestHarness harness = createClientWithTokens(899, "threadedToken");
-
-        Runnable task = () -> {
-            String token;
-            try {
-                token = harness.client.getAccessToken();
-            } catch (AccessTokenException | SigningJwsException e) {
-                throw new RuntimeException(e);
-            }
-            assertEquals("threadedToken", token);
-        };
-
-        Thread thread1 = new Thread(task);
-        Thread thread2 = new Thread(task);
-        thread1.start();
-        thread2.start();
-        thread1.join();
-        thread2.join();
-
-        verify(harness.httpRequestMock, times(1)).send();
-    }
 
     @Test
     void forceRefreshWithinGracePeriodReturnsCachedToken() throws Exception {

--- a/src/test/java/com/factset/sdk/utils/authentication/ConfidentialClientTest.java
+++ b/src/test/java/com/factset/sdk/utils/authentication/ConfidentialClientTest.java
@@ -18,10 +18,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;


### PR DESCRIPTION
### Description

- Adds ability to force refresh OAuth2 access tokens
- Introduces configurable proactive offset buffer to refresh tokens before actual expiration time
- Improves test coverage and reduces duplication in token-handling tests

<!--
Replace this comment block with detailed description detailed description
of **what** is being changed and **why**.

Here's an example of a good change description:

Added the ability to notify users when a new blog post is made
so that users can be made aware of new features as they become
available.

Used the subscription module to allow users to subscribe to
the various product categories that they are interested in. Emails
are being sent using the smtp module, configured to use FactSet's
standard smtp server.
-->

### Links
ENSC-2344

<!--
Replace this comment block with relevant links to project trackers,
like Jira, RPD or GitHub here. Example:

* Fixes #1
* Fixes #2
-->

### Testing

<!--
Replace this comment block with any testing instructions for reviewers. This is in
addition to any acceptance criteria in an associated issue.
-->

### Checklist

Ensure the following things have been met before requesting a review:

* [x] Follows all project developer guide and coding standards.
* [x] Tests have been written for the change, when applicable.
* [x] Confidential information (credentials, auth tokens, etc...) is not included.
